### PR TITLE
fixup v2.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/deis/base:v0.3.7
+FROM quay.io/deis/base:v0.3.6
 
 ENV LANG=en_US.utf8 \
     PG_MAJOR=9.4 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN buildDeps='gcc git libffi-dev libssl-dev python3-dev python3-pip python3-whe
     ln -sf /usr/bin/pip3 /usr/bin/pip && \
     mkdir -p /run/postgresql && \
     chown -R postgres /run/postgresql && \
+    pip install --upgrade setuptools && \
     pip install --disable-pip-version-check --no-cache-dir \
         envdir==0.7 \
         wal-e[aws,azure,google,swift]==v1.0.2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN buildDeps='gcc git libffi-dev libssl-dev python3-dev python3-pip python3-whe
     ln -sf /usr/bin/pip3 /usr/bin/pip && \
     mkdir -p /run/postgresql && \
     chown -R postgres /run/postgresql && \
+    # setuptools from ubuntu archives is too old for googleapis-common-protos
     pip install --upgrade setuptools && \
     pip install --disable-pip-version-check --no-cache-dir \
         envdir==0.7 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/deis/base:v0.3.6
 
 ENV LANG=en_US.utf8 \
     PG_MAJOR=9.4 \
-    PG_VERSION=9.4.14-1.pgdg16.04+1 \
+    PG_VERSION=9.4.17-1.pgdg16.04+1 \
     PGDATA=/var/lib/postgresql/data
 
 # Set this separately from those above since it depends on one of them

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/deis/base:v0.3.6
+FROM quay.io/deis/base:v0.3.7
 
 ENV LANG=en_US.utf8 \
     PG_MAJOR=9.4 \


### PR DESCRIPTION
Addresses #1 

Not quite fixed:

```
4/4/2018, 6:11:35 PM Running setup.py install for googleapis-common-protos: started
4/4/2018, 6:11:35 PM Running setup.py install for googleapis-common-protos: finished with status 'error' Complete output from command /usr/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-1dax4wi3/googleapis-common-protos/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-kywctp5p-record/install-record.txt --single-version-externally-managed --compile:
4/4/2018, 6:11:35 PM Traceback (most recent call last): 
File "<string>", line 1, in <module> 
File "/usr/lib/python3/dist-packages/setuptools/__init__.py", line 11, in <module> from setuptools.extern.six.moves import filterfalse, map 
File "/usr/lib/python3/dist-packages/setuptools/extern/__init__.py", line 1, in <module> from pkg_resources.extern import VendorImporter 
File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2927, in <module> @_call_aside 
File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2913, in _call_aside f(*args, **kwargs) 
File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2952, in _initialize_master_working_set add_activation_listener(lambda dist: dist.activate()) 
File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 956, in subscribe callback(dist) 
File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2952, in <lambda> add_activation_listener(lambda dist: dist.activate()) 
File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2515, in activate declare_namespace(pkg) 
File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2097, in declare_namespace _handle_ns(packageName, path_item) 
File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2047, in _handle_ns _rebuild_mod_path(path, packageName, module) 
File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2066, in _rebuild_mod_path orig_path.sort(key=position_in_sys_path) 
AttributeError: '_NamespacePath' object has no attribute 'sort' 
----------------------------------------
```