### PR TITLE
fix(Dockerfile): rollback to postgres:9.4-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:11-alpine
+FROM postgres:9.4-alpine
 
 ENV WALE_LOG_DESTINATION stderr
 ENV WALE_ENVDIR /etc/wal-e.d/env


### PR DESCRIPTION
We are going back to 9.4 because upgrade 11.1 would require and upgrading procedure using tools like pg_upgrade and scripts that would do the dump and restore on the postgres data directory. :see_no_evil:

Props to @kingdonb for finding this issue during an upgrade test! :+1: 

@duanhongyi @till @rwos just so you are aware.

