### PR TITLE
fix(charts): fix to point to our hub.docker repository for images

### DIFF
--- a/charts/database/templates/database-deployment.yaml
+++ b/charts/database/templates/database-deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccount: deis-database
       containers:
         - name: deis-database
-          image: quay.io/{{.Values.org}}/postgres:{{.Values.docker_tag}}
+          image: {{.Values.org}}/postgres:{{.Values.docker_tag}}
           imagePullPolicy: {{.Values.pull_policy}}
           ports:
             - containerPort: 5432


### PR DESCRIPTION
We need to fix this chart for the future. We keep our images at hub.docker for now and not quay.io.